### PR TITLE
More fixes

### DIFF
--- a/src/clj/game/cards-assets.clj
+++ b/src/clj/game/cards-assets.clj
@@ -653,7 +653,7 @@
                                 (str "Choose " (if (< 1 mus) (str mus " cards") "a card")
                                      " in Archives to shuffle into R&D")))
                  :choices {:req #(and (card-is? % :side :corp) (= (:zone %) [:discard]))
-                           :max (req (count (filter #(= "10019" (:code %)) (all-installed state :corp))))}
+                           :max (req (count (filter #(and (= "10019" (:code %)) (rezzed? %)) (all-installed state :corp))))}
                  :show-discard true
                  :priority 1
                  :once :per-turn

--- a/src/clj/game/cards-ice.clj
+++ b/src/clj/game/cards-ice.clj
@@ -519,7 +519,9 @@
                                                                    (trash state side target {:cause :subroutine})
                                                                    (do (damage state side eid :meat 2 {:unpreventable true
                                                                                             :card card})
-                                                                       (end-run state side))))}
+                                                                       (end-run state side))))
+                                                    :cancel-effect (effect (damage eid :meat 2 {:unpreventable true :card card})
+                                                                           (end-run))}
                                                    card nil))})]}
 
    "Galahad"

--- a/src/clj/game/core-actions.clj
+++ b/src/clj/game/core-actions.clj
@@ -229,8 +229,9 @@
                ;; Deregister the derezzed-events before rezzing card
                (when (:derezzed-events cdef)
                  (unregister-events state side card))
-               (when (not disabled)
-                 (card-init state side (assoc card :rezzed true)))
+               (if (not disabled)
+                 (card-init state side (assoc card :rezzed true))
+                 (update! state side (assoc card :rezzed true)))
                (doseq [h (:hosted card)]
                  (update! state side (-> h
                                          (update-in [:zone] #(map to-keyword %))

--- a/src/clj/game/core-cards.clj
+++ b/src/clj/game/core-cards.clj
@@ -1,6 +1,6 @@
 (in-ns 'game.core)
 
-(declare all-active all-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run ice?
+(declare active? all-active all-installed cards card-init deactivate card-flag? get-card-hosted handle-end-run ice?
          has-subtype? register-events remove-from-host remove-icon rezzed?
          trash update-hosted! update-ice-strength unregister-events)
 
@@ -225,9 +225,10 @@
 
 (defn enable-card
   "Enables a disabled card"
-  [state side card]
-  (let [c (dissoc card :disabled)
-        cdef (card-def c)
-        events (:events cdef)]
-    (update! state side c)
-    (card-init state side c false)))
+  [state side {:keys [disabled] :as card}]
+  (when disabled
+    (let [c (dissoc card :disabled)]
+      (update! state side c)
+      (when (active? card)
+        (card-init state side c false)))))
+

--- a/src/clj/game/core-flags.clj
+++ b/src/clj/game/core-flags.clj
@@ -210,6 +210,17 @@
 (defn installed? [card]
   (or (:installed card) (= :servers (first (:zone card)))))
 
+(defn active? [{:keys [zone] :as card}]
+  "Checks if the card is active and should receive game events/triggers."
+  (or (is-type? card "Identity")
+      (= zone [:current])
+      (and (card-is? card :side :corp)
+           (installed? card)
+           (rezzed? card))
+      (and (card-is? card :side :runner)
+           (installed? card)
+           (not (facedown? card)))))
+
 (defn untrashable-while-rezzed? [card]
   (and (card-flag? card :untrashable-while-rezzed true) (rezzed? card)))
 

--- a/src/clj/game/core-installing.clj
+++ b/src/clj/game/core-installing.clj
@@ -39,9 +39,9 @@
   some events."
   ([state side card] (deactivate state side card nil))
   ([state side card keep-counter]
+   (unregister-events state side card)
    (trigger-leave-effect state side card)
    (handle-prevent-effect state card)
-   (unregister-events state side card)
    (when (and (:memoryunits card) (:installed card) (not (:facedown card)))
      (gain state :runner :memory (:memoryunits card)))
    (when (and (find-cid (:cid card) (all-installed state side))

--- a/src/clj/game/core-rules.clj
+++ b/src/clj/game/core-rules.clj
@@ -415,10 +415,9 @@
   "Purges viruses."
   [state side]
   (trigger-event state side :pre-purge)
-  (let [rig-cards (apply concat (vals (get-in @state [:runner :rig])))
-        hosted-cards (filter :installed (mapcat :hosted rig-cards))
+  (let [rig-cards (all-installed state :runner)
         hosted-on-ice (->> (get-in @state [:corp :servers]) seq flatten (mapcat :ices) (mapcat :hosted))]
-    (doseq [card (concat rig-cards hosted-cards hosted-on-ice)]
+    (doseq [card (concat rig-cards hosted-on-ice)]
       (when (or (has-subtype? card "Virus")
                 (contains? (:counter card) :virus))
         (add-counter state :runner card :virus (- (get-in card [:counter :virus] 0)))))

--- a/src/clj/test/core-game.clj
+++ b/src/clj/test/core-game.clj
@@ -413,3 +413,23 @@
     (prompt-choice :corp "No")
     (prompt-choice :runner "Yes")
     (is (= 5 (:credit (get-runner))) "1 BP credit spent to trash CVS")))11111111
+
+(deftest purge-nested
+  "Purge nested-hosted virus counters"
+  (do-game
+    (new-game (default-corp [(qty "Cyberdex Trial" 1)])
+              (default-runner [(qty "Djinn" 1) (qty "Imp" 1) (qty "Leprechaun" 1)]))
+    (take-credits state :corp)
+    (core/gain state :runner :credit 100)
+    (play-from-hand state :runner "Leprechaun")
+    (let [lep (get-program state 0)]
+      (card-ability state :runner lep 0)
+      (prompt-select :runner (find-card "Djinn" (:hand (get-runner))))
+      (let [djinn (first (:hosted (refresh lep)))]
+        (card-ability state :runner djinn 1)
+        (prompt-select :runner (find-card "Imp" (:hand (get-runner))))
+        (let [imp (first (:hosted (refresh djinn)))]
+          (is (= 2 (get-counters imp :virus)) "Imp has 2 virus counters")
+          (take-credits state :runner)
+          (play-from-hand state :corp "Cyberdex Trial")
+          (is (= 0 (get-counters (refresh imp) :virus)) "Imp counters purged"))))))


### PR DESCRIPTION
Fix #1888 by giving Flare a `:cancel-effect`.

Fix #1890 by having MoH only count rezzed copies.

Fix #1879 by only registering events when re-enabling a card if that card is active (rezzed).

Fix #1889 by having `purge` use `all-installed` to find nested hosted viruses.
